### PR TITLE
ultragrep.yml.example change to include any app log

### DIFF
--- a/ultragrep.yml.example
+++ b/ultragrep.yml.example
@@ -1,6 +1,6 @@
 types:
   app:
-    glob: "/storage/logs/hosts/*/*/*/app*/production.log-*"
+    glob: "/storage/logs/hosts/*/*/*/*app*/production.log-*"
     format: "app"
   work:
     glob: "/storage/logs/hosts/*/*/*/work*/production.log-*"


### PR DESCRIPTION
@osheroff @grosser trying to add helpcenter logs. I have a feeling we should do something different? Should we have our own ultragrep.yml in ultragrep_deployment and not take this example?

@pdeuter 
