### PR TITLE
Add a empty logset error

### DIFF
--- a/lib/ultragrep.rb
+++ b/lib/ultragrep.rb
@@ -187,6 +187,10 @@ module Ultragrep
       lua = config.types[file_type]["lua"]
       collector = Ultragrep::LogCollector.new(config.log_path_glob(file_type), options)
       file_lists = collector.collect_files
+      if !file_lists
+        $stderr.puts("No log files found in date range #{Time.at(options.fetch(:range_start))} -- #{Time.at(options.fetch(:range_end))}")
+        exit 1
+      end
 
       request_printer = options.fetch(:printer)
       request_printer.run


### PR DESCRIPTION
/cc @zendesk/sustaining @osheroff 

### Description

Searching for logs in a date range with no log results [errors out here](https://github.com/zendesk/ultragrep/blob/master/lib/ultragrep.rb#L201) with the error:  
```
ultragrep: undefined method each for nil:NilClass (NoMethodError)
```
Add a more verbose error message so users know what went wrong.