### PR TITLE
Allow configuring a sane upper limit on IO threads

### DIFF
--- a/lib/ultragrep.rb
+++ b/lib/ultragrep.rb
@@ -202,7 +202,9 @@ module Ultragrep
 
       quoted_regexps = quote_shell_words(regexps)
 
-      file_lists.each do |files|
+      maximum_open_files = config.fetch('maximum_open_files', ifnone = file_lists.length)
+
+      file_lists.each_slice(maximum_open_files) do |files|
         print_search_list(files) if options[:verbose]
 
         children_pipes = files.map do |file|

--- a/ultragrep.yml.example
+++ b/ultragrep.yml.example
@@ -9,3 +9,4 @@ types:
     format: json
     glob: /Users/*/storage/logs/hosts/*/*/*/*app*/production.log-*.json
 default_type: app
+maximum_open_files: 25

--- a/ultragrep.yml.example
+++ b/ultragrep.yml.example
@@ -9,4 +9,4 @@ types:
     format: json
     glob: /Users/*/storage/logs/hosts/*/*/*/*app*/production.log-*.json
 default_type: app
-maximum_open_files: 25
+concurrency_limit: 10


### PR DESCRIPTION
### Description

This PR adds a new configuration option `concurrency_limit` which forces the batches of files to be read and then closed in smaller chunks, rather than keeping a process open for each file found in the glob search. For servers with a large number of logfiles, even at low IO and CPU priority ultragrep could still cause IO starvation due to all the processes opening files at once.

### Tasks/Steps to Merge

- [x] :green_apple: 
- [ ] :+1: 

### References

/cc @zendesk/sustaining 

### Risks

Log results may be returned in a slightly different order, but all the same results will still be present.