### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to RubyGems.org
+
+on:
+  push:
+    branches: main
+    paths: lib/ultragrep/version.rb
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+          
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ To look at logs from last two days for 'host.com' and foobar
 ultragrep -b 2 host.com foobar
 ```
 
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. run `bundle lock` to update `Gemfile.lock`,
+3. merge this change into `main`, and
+4. look at [the action](https://github.com/zendesk/ultragrep/actions/workflows/publish.yml) for output.
+
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/ultragrep/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
+
 ## TODO
  - should not be necessary to ship pcre headers, but it's broken on OSX Mavericks
  - Search in an array , and herarical key-value  for JSON logs


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Setting `ENV["gem_push"]` is also not necessary anymore.
This workflow relies on the main branch being named `main`. Please rename it (`main` is the standard name across Zendesk).
`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [x] Release description has been updated correctly.
- [x] The main branch is renamed from `master` to `main`.